### PR TITLE
Playlist hashes get an `_id` key value and are not handled by Active Record

### DIFF
--- a/lib/poms/base.rb
+++ b/lib/poms/base.rb
@@ -1,7 +1,7 @@
 module Poms
   module Base
     def rev
-      _rev.to_i
+      rev.to_i
     end
   end
 end

--- a/lib/poms/builder.rb
+++ b/lib/poms/builder.rb
@@ -8,7 +8,7 @@ module Poms
     def self.process_hash(hash)
       return unless hash
       underscored_hash = {}
-      hash.each { |k,v| underscored_hash[k.underscore] = v }
+      hash.each { |k,v| underscored_hash[k.gsub(/^_/,'').underscore] = v }
       class_name = (underscored_hash['type'] || "Typeless").capitalize
       class_name = pomsify_class_name(class_name)
       begin

--- a/lib/poms/builder.rb
+++ b/lib/poms/builder.rb
@@ -8,7 +8,7 @@ module Poms
     def self.process_hash(hash)
       return unless hash
       underscored_hash = {}
-      hash.each { |k,v| underscored_hash[k.gsub(/^_/,'').underscore] = v }
+      hash.each { |k,v| underscored_hash[k.gsub(/^_/, '').underscore] = v }
       class_name = (underscored_hash['type'] || "Typeless").capitalize
       class_name = pomsify_class_name(class_name)
       begin


### PR DESCRIPTION
Remove leading underscore from key value to resolve this.

Tom, ik liep hier tegen aan wanneer ik `Poms.fetch` op een Playlist mid deed.

```
1.9.3p551>   Poms.fetch pl.mid
ActiveRecord::UnknownAttributeError: unknown attribute: _id
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/attribute_assignment.rb:50:in `rescue in _assign_attribute'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/attribute_assignment.rb:45:in `_assign_attribute'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/attribute_assignment.rb:32:in `block in assign_attributes'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/attribute_assignment.rb:26:in `each'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/attribute_assignment.rb:26:in `assign_attributes'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/core.rb:455:in `init_attributes'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/core.rb:198:in `initialize'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/inheritance.rb:30:in `new'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/activerecord-4.1.4/lib/active_record/inheritance.rb:30:in `new'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/poms-0.0.6/lib/poms/builder.rb:17:in `process_hash'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/poms-0.0.6/lib/poms.rb:27:in `fetch'
	from (irb):82
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/brice-0.4.0/lib/brice/rc/070_prompt.rb:21:in `block in evaluate'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/1.9.1/benchmark.rb:280:in `measure'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/brice-0.4.0/lib/brice/rc/070_prompt.rb:21:in `evaluate'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/railties-4.1.4/lib/rails/commands/console.rb:90:in `start'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/railties-4.1.4/lib/rails/commands/console.rb:9:in `start'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/railties-4.1.4/lib/rails/commands/commands_tasks.rb:69:in `console'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/railties-4.1.4/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
	from /home/richard/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/railties-4.1.4/lib/rails/commands.rb:17:in `<top (required)>'
	from script/rails:6:in `require'
```