### PR TITLE
Broadcast hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Poms Release notes
 
+## 1.2.0
+
+* [#24](https://github.com/brightin/poms/pull/24) Add functions to access the internals of a Poms broadcast hash.
+
 ## 1.1.1
 
 * [#22](https://github.com/brightin/poms/pull/22) Refactor descendant-related code into views.

--- a/lib/poms.rb
+++ b/lib/poms.rb
@@ -56,6 +56,8 @@ module Poms
     get_json(uri)
   end
 
+  alias_method :fetch_broadcast, :fetch_raw_json
+
   def fetch_group(mid)
     uri = Views.by_group(mid)
     get_bare_json(uri)

--- a/spec/lib/poms/fields_spec.rb
+++ b/spec/lib/poms/fields_spec.rb
@@ -1,46 +1,45 @@
 require 'spec_helper'
 
 describe Poms::Fields do
-  subject { Poms::Fields }
   let(:poms_data) { JSON.parse File.read('spec/fixtures/poms_broadcast.json') }
 
   describe '#title' do
     it 'returns the first MAIN title' do
-      expect(subject.title(poms_data)).to eq('VRijland')
+      expect(described_class.title(poms_data)).to eq('VRijland')
     end
   end
 
   describe '#description' do
     it 'returns the first MAIN description' do
-      expect(subject.description(poms_data)).to eq("Li biedt Barry een baantje \
-aan bij de uitdragerij en vraagt zich meteen af of dat wel zo slim was. Timon \
-en Joep zien de criminele organisatie de Rijland Angels. Timon wil naar hun \
-loods, maar is dat wel een goed idee?")
+      expect(described_class.description(poms_data)).to eq("Li biedt Barry \
+een baantje aan bij de uitdragerij en vraagt zich meteen af of dat wel zo slim \
+was. Timon en Joep zien de criminele organisatie de Rijland Angels. Timon wil \
+naar hun loods, maar is dat wel een goed idee?")
     end
   end
 
   describe '#first_image_id' do
-    it 'returns the if of the first image' do
-      expect(subject.first_image_id(poms_data)).to eq('184169')
+    it 'returns the id of the first image' do
+      expect(described_class.first_image_id(poms_data)).to eq('184169')
     end
   end
 
   describe '#rev' do
     it 'returns the current Poms revision' do
-      expect(subject.rev(poms_data)).to eq(60)
+      expect(described_class.rev(poms_data)).to eq(60)
     end
   end
 
   describe '#odi_streams' do
     it 'returns an array of stream types' do
-      expect(subject.odi_streams(poms_data)).to match_array(
+      expect(described_class.odi_streams(poms_data)).to match_array(
         %w(adaptive h264_sb h264_bb h264_std wvc1_std wmv_sb wmv_bb))
     end
   end
 
   describe '#available_until' do
     it 'returns the enddate of the INTERNETVOD prediction' do
-      expect(subject.available_until(poms_data))
+      expect(described_class.available_until(poms_data))
         .to eq('Sat, 27 Jun 2015 07:12:48 +0200')
     end
   end

--- a/spec/lib/poms/fields_spec.rb
+++ b/spec/lib/poms/fields_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Poms::Fields do
+  subject { Poms::Fields }
+  let(:poms_data) { JSON.parse File.read('spec/fixtures/poms_broadcast.json') }
+
+  describe '#title' do
+    it 'returns the first MAIN title' do
+      expect(subject.title(poms_data)).to eq('VRijland')
+    end
+  end
+
+  describe '#description' do
+    it 'returns the first MAIN description' do
+      expect(subject.description(poms_data)).to eq("Li biedt Barry een baantje \
+aan bij de uitdragerij en vraagt zich meteen af of dat wel zo slim was. Timon \
+en Joep zien de criminele organisatie de Rijland Angels. Timon wil naar hun \
+loods, maar is dat wel een goed idee?")
+    end
+  end
+
+  describe '#first_image_id' do
+    it 'returns the if of the first image' do
+      expect(subject.first_image_id(poms_data)).to eq('184169')
+    end
+  end
+
+  describe '#rev' do
+    it 'returns the current Poms revision' do
+      expect(subject.rev(poms_data)).to eq(60)
+    end
+  end
+
+  describe '#odi_streams' do
+    it 'returns an array of stream types' do
+      expect(subject.odi_streams(poms_data)).to match_array(
+        %w(adaptive h264_sb h264_bb h264_std wvc1_std wmv_sb wmv_bb))
+    end
+  end
+
+  describe '#available_until' do
+    it 'returns the enddate of the INTERNETVOD prediction' do
+      expect(subject.available_until(poms_data))
+        .to eq('Sat, 27 Jun 2015 07:12:48 +0200')
+    end
+  end
+end


### PR DESCRIPTION
We can now fetch broadcasts as a hash and then use `Poms::Fields` functions to access the internals (or just `[]`).