### PR TITLE
Add timestamp require in the right place

### DIFF
--- a/lib/poms/api/search.rb
+++ b/lib/poms/api/search.rb
@@ -1,3 +1,5 @@
+require 'poms/timestamp'
+
 module Poms
   module Api
     # Map search parameters to POMS specific format

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'fabrication'
 require 'vcr'
 require 'timecop'
 require 'poms'
-require 'poms/timestamp'
 
 WebMock.disable_net_connect!
 


### PR DESCRIPTION
It was required in the spec helper, which made the spec succeed, but the actual code fail.