### PR TITLE
Read default config from ENV

### DIFF
--- a/lib/poms.rb
+++ b/lib/poms.rb
@@ -54,7 +54,11 @@ module Poms
   end
 
   def config
-    @config ||= OpenStruct.new
+    @config ||= OpenStruct.new(
+      key: ENV['POMS_KEY'],
+      origin: ENV['POMS_ORIGIN'],
+      secret: ENV['POMS_SECRET']
+    )
   end
 
   def credentials


### PR DESCRIPTION
You can and probably should use the `Poms.configure` syntax, but it is a common standard to also try to read environment variables for configuration.