### PR TITLE
Move sign method from Client to Auth

### DIFF
--- a/.todo.reek
+++ b/.todo.reek
@@ -1,9 +1,6 @@
 ---
 UncommunicativeVariableName:
   exclude:
-  - Poms::Api::Auth#self.encode
-  - Poms::Api::Auth#self.params_string
-  - Poms::Api::Auth#self.params_string
   - Poms::Fields#available_until
   - Poms::Fields#odi_streams
   - Poms::MergedSeries#serie_mids

--- a/.todo.reek
+++ b/.todo.reek
@@ -41,9 +41,6 @@ LongParameterList:
 FeatureEnvy:
   exclude:
   - Poms#first
-  - Poms::Api::Auth#sign
-  - Poms::Api::Auth#encode_message
-  - Poms::Api::Auth#generate_message
   - Poms::Api::Drivers::NetHttp#attempt_request
   - Poms::Api::Drivers::NetHttp#execute
   - Poms::Api::Drivers::NetHttp#prepare_request

--- a/.todo.reek
+++ b/.todo.reek
@@ -30,7 +30,7 @@ NilCheck:
 TooManyStatements:
   exclude:
   - Poms::Fields#odi_streams
-  - Poms::Api::Client#sign
+  - Poms::Api::Auth#sign
   - Poms::Api::Drivers::NetHttp#attempt_request
   - Poms::Api::PaginationClient#execute
 LongParameterList:
@@ -41,6 +41,9 @@ LongParameterList:
 FeatureEnvy:
   exclude:
   - Poms#first
+  - Poms::Api::Auth#sign
+  - Poms::Api::Auth#encode_message
+  - Poms::Api::Auth#generate_message
   - Poms::Api::Drivers::NetHttp#attempt_request
   - Poms::Api::Drivers::NetHttp#execute
   - Poms::Api::Drivers::NetHttp#prepare_request

--- a/lib/poms/api/auth.rb
+++ b/lib/poms/api/auth.rb
@@ -13,10 +13,17 @@ module Poms
       # @see message
       # @param secret The Poms API secret key
       # @param message The message that needs to be hashed.
+
+
       def self.encode(secret, message)
         sha256 = OpenSSL::Digest.new('sha256')
         digest = OpenSSL::HMAC.digest(sha256, secret, message)
         Base64.encode64(digest).strip
+      end
+
+      def self.encoded_message(uri, credentials, timestamp)
+        message = message(uri, credentials.origin, timestamp)
+        encode(credentials.secret, message)
       end
 
       # Creates the header that is used for authenticating a request to the Poms
@@ -24,12 +31,12 @@ module Poms
       #
       # @param uri An instance of an Addressable::URI of the requested uri
       # @param origin The origin header
-      # @param date The date as an RFC822 string
+      # @param timestamp The time as an RFC822 string
       # @param params The url params as a ruby hash
-      def self.message(uri, origin, date)
+      def self.message(uri, origin, timestamp)
         [
           "origin:#{origin}",
-          "x-npo-date:#{date}",
+          "x-npo-date:#{timestamp}",
           "uri:#{uri.path}",
           params_string(uri.query_values)
         ].compact.join(',')
@@ -37,7 +44,7 @@ module Poms
 
       def self.params_string(params)
         return unless params
-        params.map { |k, v| "#{k}:#{v}" }.sort.join(',')
+        params.map { |key, value| "#{key}:#{value}" }.sort.join(',')
       end
 
       private_class_method :params_string

--- a/lib/poms/api/auth.rb
+++ b/lib/poms/api/auth.rb
@@ -11,27 +11,20 @@ module Poms
       # consisting of a message that is hashed with a secret.
       #
       # @see message
-      # @param secret The Poms API secret key
-      # @param message The message that needs to be hashed.
-
-
-      def self.encode(secret, message)
-        sha256 = OpenSSL::Digest.new('sha256')
-        digest = OpenSSL::HMAC.digest(sha256, secret, message)
-        Base64.encode64(digest).strip
-      end
-
+      # @param uri An instance of an Addressable::URI of the requested uri
+      # @param credentials The Poms API credentials
+      # @param timestamp The time as an RFC822 string
       def self.encoded_message(uri, credentials, timestamp)
         message = message(uri, credentials.origin, timestamp)
-        encode(credentials.secret, message)
+        sha256 = OpenSSL::Digest.new('sha256')
+        digest = OpenSSL::HMAC.digest(sha256, credentials.secret, message)
+        Base64.encode64(digest).strip
       end
 
       # Creates the header that is used for authenticating a request to the Poms
       # API.
       #
-      # @param uri An instance of an Addressable::URI of the requested uri
       # @param origin The origin header
-      # @param timestamp The time as an RFC822 string
       # @param params The url params as a ruby hash
       def self.message(uri, origin, timestamp)
         [

--- a/lib/poms/api/auth.rb
+++ b/lib/poms/api/auth.rb
@@ -7,6 +7,8 @@ module Poms
     #
     # see: http://wiki.publiekeomroep.nl/display/npoapi/Algemeen
     module Auth
+      module_function
+
       # Create an auth header for the Poms API. This is a codified string
       # consisting of a message that is hashed with a secret.
       #
@@ -14,9 +16,9 @@ module Poms
       # @param uri An instance of an Addressable::URI of the requested uri
       # @param credentials The Poms API credentials
       # @param timestamp The time as an RFC822 string
-      def self.encoded_message(uri, credentials, timestamp)
-        message = message(uri, credentials.origin, timestamp)
+      def encoded_message(uri, credentials, timestamp)
         sha256 = OpenSSL::Digest.new('sha256')
+        message = generate_message(uri, credentials.origin, timestamp)
         digest = OpenSSL::HMAC.digest(sha256, credentials.secret, message)
         Base64.encode64(digest).strip
       end
@@ -26,7 +28,7 @@ module Poms
       #
       # @param origin The origin header
       # @param params The url params as a ruby hash
-      def self.message(uri, origin, timestamp)
+      def generate_message(uri, origin, timestamp)
         [
           "origin:#{origin}",
           "x-npo-date:#{timestamp}",
@@ -35,12 +37,12 @@ module Poms
         ].compact.join(',')
       end
 
-      def self.params_string(params)
+      def params_string(params)
         return unless params
         params.map { |key, value| "#{key}:#{value}" }.sort.join(',')
       end
 
-      private_class_method :params_string
+      private_class_method :generate_message, :params_string
     end
   end
 end

--- a/lib/poms/api/client.rb
+++ b/lib/poms/api/client.rb
@@ -56,10 +56,8 @@ module Poms
 
       def sign(request, credentials, clock = Time.now)
         timestamp = clock.rfc822
-        origin = credentials.origin
-        message = Auth.message(request.uri, origin, timestamp)
-        encoded_message = Auth.encode(credentials.secret, message)
-        request['Origin'] = origin
+        encoded_message = Auth.encoded_message(request.uri, credentials, timestamp)
+        request['Origin'] = credentials.origin
         request['X-NPO-Date'] = timestamp
         request['Authorization'] = "NPO #{credentials.key}:#{encoded_message}"
         request

--- a/lib/poms/api/client.rb
+++ b/lib/poms/api/client.rb
@@ -18,7 +18,7 @@ module Poms
       def get(uri, credentials, headers = {})
         handle_response(
           execute(
-            sign(
+            Auth.sign(
               prepare_get(uri, headers),
               credentials
             )
@@ -29,7 +29,7 @@ module Poms
       def post(uri, body, credentials, headers = {})
         handle_response(
           execute(
-            sign(
+            Auth.sign(
               prepare_post(uri, body, headers),
               credentials
             )
@@ -52,15 +52,6 @@ module Poms
 
       def prepare_post(uri, body, headers = {})
         Request.post(uri, body, headers)
-      end
-
-      def sign(request, credentials, clock = Time.now)
-        timestamp = clock.rfc822
-        encoded_message = Auth.encoded_message(request.uri, credentials, timestamp)
-        request['Origin'] = credentials.origin
-        request['X-NPO-Date'] = timestamp
-        request['Authorization'] = "NPO #{credentials.key}:#{encoded_message}"
-        request
       end
     end
   end

--- a/lib/poms/api/drivers/net_http.rb
+++ b/lib/poms/api/drivers/net_http.rb
@@ -60,8 +60,7 @@ module Poms
           elsif request_description.post?
             Net::HTTP::Post.new(uri)
           else
-            raise ArgumentError,
-                  'can only execute GET or POST requests'
+            raise ArgumentError, 'can only execute GET or POST requests'
           end
         end
       end

--- a/spec/lib/poms/api/auth_spec.rb
+++ b/spec/lib/poms/api/auth_spec.rb
@@ -5,36 +5,12 @@ require 'spec_helper'
 module Poms
   module Api
     RSpec.describe Auth do
-      let(:timestamp) { Date.parse('2015-01-01') }
-
-      describe '.message' do
-        it 'creates a message' do
-          message = described_class.message(
-            Addressable::URI.parse('/v1/api/media/redirects/'),
-            'http://zapp.nl',
-            timestamp.rfc822
-          )
-          expect(message).to eq(
-            'origin:http://zapp.nl,x-npo-date:Thu, 1 Jan 2015 00:00:00 '\
-            '+0000,uri:/v1/api/media/redirects/')
-        end
-
-        it 'sorts the params' do
-          message = described_class.message(
-            Addressable::URI.parse('/v1/api/media/redirects/?b=1&a=2'),
-            'http://zapp.nl',
-            timestamp.rfc822
-          )
-          expect(message).to eq(
-            'origin:http://zapp.nl,x-npo-date:Thu, 1 Jan 2015 00:00:00 '\
-            '+0000,uri:/v1/api/media/redirects/,a:2,b:1')
-        end
-      end
-
       describe '.encoded_message' do
         it 'returns the encoded message' do
           uri = Addressable::URI.parse('/v1/api/media/')
+          timestamp = Date.parse('2015-01-01')
           credentials = Configuration.new
+
           expect(described_class.encoded_message(uri, credentials, timestamp))
             .to eq('DL0JOB6ahzRV/8qGduGa9D2dHwn1iArUqb46NsQzTbk=')
         end

--- a/spec/lib/poms/api/auth_spec.rb
+++ b/spec/lib/poms/api/auth_spec.rb
@@ -7,13 +7,6 @@ module Poms
     RSpec.describe Auth do
       let(:timestamp) { Date.parse('2015-01-01') }
 
-      describe '.encode' do
-        it 'encodes the message with the secret' do
-          expect(described_class.encode('secret', 'message'))
-            .to eq('i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs=')
-        end
-      end
-
       describe '.message' do
         it 'creates a message' do
           message = described_class.message(

--- a/spec/lib/poms/api/auth_spec.rb
+++ b/spec/lib/poms/api/auth_spec.rb
@@ -1,33 +1,51 @@
 require 'poms/api/auth'
+require 'poms/configuration'
 require 'spec_helper'
 
-RSpec.describe Poms::Api::Auth do
-  describe '.encode' do
-    it 'encodes the message with the secret' do
-      expect(described_class.encode('secret', 'message'))
-        .to eq('i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs=')
-    end
-  end
+module Poms
+  module Api
+    RSpec.describe Auth do
+      let(:timestamp) { Date.parse('2015-01-01') }
 
-  describe '.message' do
-    it 'creates a message' do
-      message = described_class.message(
-        Addressable::URI.parse('/v1/api/media/redirects/'),
-        'http://zapp.nl',
-        Date.parse('2015-01-01').rfc822)
-      expect(message).to eq(
-        'origin:http://zapp.nl,x-npo-date:Thu, 1 Jan 2015 00:00:00 '\
-        '+0000,uri:/v1/api/media/redirects/')
-    end
+      describe '.encode' do
+        it 'encodes the message with the secret' do
+          expect(described_class.encode('secret', 'message'))
+            .to eq('i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs=')
+        end
+      end
 
-    it 'sorts the params' do
-      message = described_class.message(
-        Addressable::URI.parse('/v1/api/media/redirects/?b=1&a=2'),
-        'http://zapp.nl',
-        Date.parse('2015-01-01').rfc822)
-      expect(message).to eq(
-        'origin:http://zapp.nl,x-npo-date:Thu, 1 Jan 2015 00:00:00 '\
-        '+0000,uri:/v1/api/media/redirects/,a:2,b:1')
+      describe '.message' do
+        it 'creates a message' do
+          message = described_class.message(
+            Addressable::URI.parse('/v1/api/media/redirects/'),
+            'http://zapp.nl',
+            timestamp.rfc822
+          )
+          expect(message).to eq(
+            'origin:http://zapp.nl,x-npo-date:Thu, 1 Jan 2015 00:00:00 '\
+            '+0000,uri:/v1/api/media/redirects/')
+        end
+
+        it 'sorts the params' do
+          message = described_class.message(
+            Addressable::URI.parse('/v1/api/media/redirects/?b=1&a=2'),
+            'http://zapp.nl',
+            timestamp.rfc822
+          )
+          expect(message).to eq(
+            'origin:http://zapp.nl,x-npo-date:Thu, 1 Jan 2015 00:00:00 '\
+            '+0000,uri:/v1/api/media/redirects/,a:2,b:1')
+        end
+      end
+
+      describe '.encoded_message' do
+        it 'returns the encoded message' do
+          uri = Addressable::URI.parse('/v1/api/media/')
+          credentials = Configuration.new
+          expect(described_class.encoded_message(uri, credentials, timestamp))
+            .to eq('DL0JOB6ahzRV/8qGduGa9D2dHwn1iArUqb46NsQzTbk=')
+        end
+      end
     end
   end
 end

--- a/spec/lib/poms/api/auth_spec.rb
+++ b/spec/lib/poms/api/auth_spec.rb
@@ -5,14 +5,30 @@ require 'spec_helper'
 module Poms
   module Api
     RSpec.describe Auth do
-      describe '.encoded_message' do
-        it 'returns the encoded message' do
-          uri = Addressable::URI.parse('/v1/api/media/')
-          timestamp = Date.parse('2015-01-01')
-          credentials = Configuration.new
+      let(:timestamp) { Time.new(2016, 4, 19, 7, 48, 46, '+02:00') }
+      let(:uri) { Addressable::URI.parse('/v1/api/media/') }
+      let(:credentials) do
+        double(
+          'Credentials',
+          origin: 'my origin',
+          key: 'mykey',
+          secret: 'mysecret'
+        )
+      end
 
-          expect(described_class.encoded_message(uri, credentials, timestamp))
-            .to eq('DL0JOB6ahzRV/8qGduGa9D2dHwn1iArUqb46NsQzTbk=')
+      describe '.sign' do
+        it 'signs requests' do
+          headers = {}
+          request = Request.get(uri, nil, headers)
+          signed_request = described_class.sign(request, credentials, timestamp)
+
+          expect(signed_request['Origin']).to eql('my origin')
+          expect(signed_request['X-NPO-Date']).to eql(
+            'Tue, 19 Apr 2016 07:48:46 +0200'
+          )
+          expect(signed_request['Authorization']).to eql(
+            'NPO mykey:PfeMP5/G9NmyprlaCsxiGU2F8l85OWRbDOj+kLbvuFA='
+          )
         end
       end
     end

--- a/spec/lib/poms/api/client_spec.rb
+++ b/spec/lib/poms/api/client_spec.rb
@@ -30,19 +30,6 @@ module Poms
         expect(request.body).to eql(body)
       end
 
-      it 'signs requests' do
-        request = described_class.prepare_get(uri)
-        clock = Time.new(2016, 4, 19, 7, 48, 46, '+02:00')
-        signed_request = described_class.sign(request, credentials, clock)
-        expect(signed_request['Origin']).to eql('my origin')
-        expect(signed_request['X-NPO-Date']).to eql(
-          'Tue, 19 Apr 2016 07:48:46 +0200'
-        )
-        expect(signed_request['Authorization']).to eql(
-          'NPO mykey:SjeYLRMQ4W0hI8ZI8JAR6Y9sHUWxZAKA/vg/vlBCw9o='
-        )
-      end
-
       it 'executes bare requests' do
         stub_request(:get, 'https://example.com/some/uri').to_return(
           body: 'stubbed response',


### PR DESCRIPTION
`Auth` is still called in `Client`, but only once with two arguments