### PR TITLE
Make credentials a callable object on Configuration

### DIFF
--- a/lib/poms.rb
+++ b/lib/poms.rb
@@ -38,25 +38,32 @@ module Poms
   # @param [String] mid
   # @raise Api::Client::HttpMissingError
   def first!(mid)
-    Api::JsonClient.get(Api::URIs::Media.single(mid, config.base_uri), config)
+    Api::JsonClient.get(
+      Api::URIs::Media.single(mid, config.base_uri),
+      config.credentials
+    )
   end
 
   def fetch(arg)
-    Api::JsonClient.post(Api::URIs::Media.multiple(config.base_uri), Array(arg), config)
+    Api::JsonClient.post(
+      Api::URIs::Media.multiple(config.base_uri),
+      Array(arg),
+      config.credentials
+    )
   end
 
   def descendants(mid, search_params = {})
     Api::PaginationClient.post(
       Api::URIs::Media.descendants(mid, config.base_uri),
       Api::Search.build(search_params),
-      config
+      config.credentials
     )
   end
 
   def members(mid)
     Api::PaginationClient.get(
       Api::URIs::Media.members(mid, config.base_uri),
-      config
+      config.credentials
     )
   end
 

--- a/lib/poms/api/pagination_client.rb
+++ b/lib/poms/api/pagination_client.rb
@@ -7,12 +7,16 @@ module Poms
     module PaginationClient
       module_function
 
-      def get(uri, config)
-        execute(uri) { |page_uri| Api::JsonClient.get(page_uri, config) }
+      def get(uri, credentials)
+        execute(uri) do |page_uri|
+          Api::JsonClient.get(page_uri, credentials)
+        end
       end
 
-      def post(uri, body, config)
-        execute(uri) { |page_uri| Api::JsonClient.post(page_uri, body, config) }
+      def post(uri, body, credentials)
+        execute(uri) do |page_uri|
+          Api::JsonClient.post(page_uri, body, credentials)
+        end
       end
 
       def execute(uri)

--- a/lib/poms/configuration.rb
+++ b/lib/poms/configuration.rb
@@ -25,6 +25,10 @@ module Poms
       freeze
     end
 
+    def credentials
+      @credentials ||= OpenStruct.new(key: key, origin: origin, secret: secret)
+    end
+
     private
 
     def validate
@@ -45,6 +49,7 @@ module Poms
     end
 
     def reset
+      @credentials = nil
       self.key = ENV['POMS_KEY']
       self.origin = ENV['POMS_ORIGIN']
       self.secret = ENV['POMS_SECRET']


### PR DESCRIPTION
We were passing on the config to the clients and calling it credentials when it
comes in.

This commit will limit the passed value to the credential values only.