### PR TITLE
Add additional look up methods to Poms::Fields

### DIFF
--- a/.todo.reek
+++ b/.todo.reek
@@ -13,20 +13,11 @@ DuplicateMethodCall:
   - Poms::Api::RequestExecution#headers
   - Poms::Builderless::Clip#position
   - Poms::Builderless::Clip#video_url
-  - Poms::Fields#available_until
-  - Poms::Fields#first_image_id
-  - Poms::Fields#image_id
-  - Poms::Fields#odi_streams
+  - Poms::Field
 UtilityFunction:
   exclude:
   - Poms::Api::RequestExecution#execute_ssl_request
-  - Poms::Fields#available_until
-  - Poms::Fields#image_id
-  - Poms::Fields#images
-  - Poms::Fields#odi_streams
-  - Poms::Fields#position
-  - Poms::Fields#rev
-  - Poms::Fields#value_of_type
+  - Poms::Fields
 NilCheck:
   exclude:
   - Poms::Fields#odi_streams

--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -72,8 +72,7 @@ module Poms
     end
 
     def schedule_events(item)
-      events = item['scheduleEvents']
-      return if events.blank?
+      events = item.fetch('scheduleEvents', [])
       events.map do |event|
         {
           'starts_at' => Timestamp.convert(event['start']),

--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -32,6 +32,10 @@ module Poms
       image_id(images(item).first)
     end
 
+    def mid(item)
+      item['mid']
+    end
+
     # Returns the revision from a Poms hash.
     def rev(item)
       item['_rev'].to_i

--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -1,3 +1,5 @@
+require 'poms/timestamp'
+
 module Poms
   # This module contains functions to extract things from a Poms hash that may
   # be harder to access, or are accessed in multiple places.
@@ -60,13 +62,24 @@ module Poms
       internetvod = item['predictions']
                     .find { |p| p['platform'] == 'INTERNETVOD' }
       return unless internetvod
-      Poms::Timestamp.convert(internetvod['publishStop'])
+      Timestamp.convert(internetvod['publishStop'])
     end
 
     # Returns the position in the parent context if it is present.
     def position(item)
       parent = item['memberOf']
       parent.first['index'] if parent.present?
+    end
+
+    def schedule_events(item)
+      events = item['scheduleEvents']
+      return if events.blank?
+      events.map do |event|
+        {
+          'starts_at' => Timestamp.convert(event['start']),
+          'ends_at' => Timestamp.convert(event['start'] + event['duration'])
+        }
+      end
     end
 
     private

--- a/spec/lib/poms/fields_spec.rb
+++ b/spec/lib/poms/fields_spec.rb
@@ -1,98 +1,114 @@
 require 'spec_helper'
 require 'poms/fields'
 
-describe Poms::Fields do
-  let(:poms_data) { JSON.parse File.read('spec/fixtures/poms_broadcast.json') }
+module Poms
+  describe Fields do
+    let(:poms_data) { JSON.parse File.read('spec/fixtures/poms_broadcast.json') }
 
-  describe '#title' do
-    it 'returns the first MAIN title' do
-      expect(described_class.title(poms_data)).to eq('VRijland')
+    describe '.title' do
+      it 'returns the first MAIN title' do
+        expect(described_class.title(poms_data)).to eq('VRijland')
+      end
+
+      it 'returns nil if no title can be found' do
+        expect(described_class.title(poms_data, 'NONEXISTANTTYPE')).to be_nil
+      end
     end
 
-    it 'returns nil if no title can be found' do
-      expect(described_class.title(poms_data, 'NONEXISTANTTYPE')).to be_nil
-    end
-  end
-
-  describe '#description' do
-    it 'returns the first MAIN description' do
-      expect(described_class.description(poms_data)).to eq("Li biedt Barry \
+    describe '.description' do
+      it 'returns the first MAIN description' do
+        expect(described_class.description(poms_data)).to eq("Li biedt Barry \
 een baantje aan bij de uitdragerij en vraagt zich meteen af of dat wel zo slim \
 was. Timon en Joep zien de criminele organisatie de Rijland Angels. Timon wil \
 naar hun loods, maar is dat wel een goed idee?")
+      end
+
+      it 'returns nil if no description can be found' do
+        expect(described_class.description(poms_data, 'NONEXISTANTTYPE'))
+          .to be_nil
+      end
     end
 
-    it 'returns nil if no description can be found' do
-      expect(described_class.description(poms_data, 'NONEXISTANTTYPE'))
-        .to be_nil
-    end
-  end
+    describe '.image_id' do
+      it 'returns the id of the image' do
+        expect(described_class.image_id(poms_data['images'].first))
+          .to eq('184169')
+      end
 
-  describe '#image_id' do
-    it 'returns the id of the image' do
-      expect(described_class.image_id(poms_data['images'].first))
-        .to eq('184169')
-    end
-
-    it 'returns nil if there is no image' do
-      expect(described_class.image_id({})).to be_nil
-    end
-  end
-
-  describe '#first_image_id' do
-    it 'returns the id of the first image' do
-      expect(described_class.first_image_id(poms_data)).to eq('184169')
+      it 'returns nil if there is no image' do
+        expect(described_class.image_id({})).to be_nil
+      end
     end
 
-    it 'returns nil if there is no image' do
-      expect(described_class.first_image_id({})).to be_nil
-    end
-  end
+    describe '.first_image_id' do
+      it 'returns the id of the first image' do
+        expect(described_class.first_image_id(poms_data)).to eq('184169')
+      end
 
-  describe '#rev' do
-    it 'returns the current Poms revision' do
-      expect(described_class.rev(poms_data)).to eq(60)
-    end
-
-    it 'returns 0 if it cannot be found' do
-      expect(described_class.rev({})).to eq(0)
-    end
-  end
-
-  describe '#odi_streams' do
-    it 'returns an array of stream types' do
-      expect(described_class.odi_streams(poms_data)).to match_array(
-        %w(adaptive h264_sb h264_bb h264_std wvc1_std wmv_sb wmv_bb))
+      it 'returns nil if there is no image' do
+        expect(described_class.first_image_id({})).to be_nil
+      end
     end
 
-    it 'returns an empty array of no stream types are found' do
-      expect(described_class.odi_streams({})).to eq([])
-    end
-  end
+    describe '.rev' do
+      it 'returns the current Poms revision' do
+        expect(described_class.rev(poms_data)).to eq(60)
+      end
 
-  describe '#available_until' do
-    it 'returns the enddate of the INTERNETVOD prediction' do
-      expect(described_class.available_until(poms_data))
-        .to eq('Sat, 27 Jun 2015 07:12:48 +0200')
-    end
-
-    it 'returns nil if the INTERNETVOD has no publishStop' do
-      expect(
-        described_class.available_until(
-          'predictions' => [
-            { 'state' => 'REALIZED', 'platform' => 'INTERNETVOD' }]))
-        .to be_nil
-    end
-  end
-
-  describe '#position' do
-    it 'returns the position' do
-      clip = JSON.parse File.read('spec/fixtures/poms_clip.json')
-      expect(described_class.position(clip)).to eq(1)
+      it 'returns 0 if it cannot be found' do
+        expect(described_class.rev({})).to eq(0)
+      end
     end
 
-    it 'returns nil if it not a member of anything' do
-      expect(described_class.position(poms_data)).to be_nil
+    describe '.odi_streams' do
+      it 'returns an array of stream types' do
+        expect(described_class.odi_streams(poms_data)).to match_array(
+          %w(adaptive h264_sb h264_bb h264_std wvc1_std wmv_sb wmv_bb))
+      end
+
+      it 'returns an empty array of no stream types are found' do
+        expect(described_class.odi_streams({})).to eq([])
+      end
+    end
+
+    describe '.available_until' do
+      it 'returns the enddate of the INTERNETVOD prediction' do
+        expect(described_class.available_until(poms_data))
+          .to eq('Sat, 27 Jun 2015 07:12:48 +0200')
+      end
+
+      it 'returns nil if the INTERNETVOD has no publishStop' do
+        expect(
+          described_class.available_until(
+            'predictions' => [
+              { 'state' => 'REALIZED', 'platform' => 'INTERNETVOD' }]))
+          .to be_nil
+      end
+    end
+
+    describe '.position' do
+      it 'returns the position' do
+        clip = JSON.parse File.read('spec/fixtures/poms_clip.json')
+        expect(described_class.position(clip)).to eq(1)
+      end
+
+      it 'returns nil if it not a member of anything' do
+        expect(described_class.position(poms_data)).to be_nil
+      end
+    end
+
+    describe '.schedule_events' do
+      it 'returns a collection of objects with a start and end time' do
+        expect(described_class.schedule_events(poms_data)).to eq(
+          [
+            {
+              'starts_at' => Timestamp.convert(1_369_757_335_000),
+              'ends_at' => Timestamp.convert(1_369_758_384_000)
+
+            }
+          ]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Use `Fields.schedule_events` to return a collection of event start and end
times.