### PR TITLE
Handle case of key without value in value_of_type

### DIFF
--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -93,6 +93,7 @@ module Poms
     # @param key The key of the array we want to look in
     # @param type The type to select
     def value_of_type(item, key, type)
+      return unless item[key]
       res = item[key].find { |value| value['type'] == type }
       return unless res
       res['value']

--- a/spec/lib/poms/fields_spec.rb
+++ b/spec/lib/poms/fields_spec.rb
@@ -15,6 +15,10 @@ module Poms
       it 'returns nil if no title can be found' do
         expect(described_class.title(poms_data, 'NONEXISTANTTYPE')).to be_nil
       end
+
+      it 'returns nil if there is no title' do
+        expect(described_class.title({})).to be_nil
+      end
     end
 
     describe '.description' do
@@ -28,6 +32,10 @@ naar hun loods, maar is dat wel een goed idee?")
       it 'returns nil if no description can be found' do
         expect(described_class.description(poms_data, 'NONEXISTANTTYPE'))
           .to be_nil
+      end
+
+      it 'returns nil if there is no description' do
+        expect(described_class.description({})).to be_nil
       end
     end
 


### PR DESCRIPTION
There was an error with descriptions being requested when they weren't present in Poms. This should fix that issue.