### PR TITLE
Prevent empty schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Poms Release notes
 
+## 2.1.0
+
+* The `scheduled_now` and `scheduled_next` functions always return the most recent and upcoming shows. They shouldn't return nil anymore, even if something is not live at the moment (during a commercial break for instance).
+
 ## 2.0.1
 
 * Fix search parameter `type`. This didn't get picked up properly before, but is now used in the search.

--- a/lib/poms.rb
+++ b/lib/poms.rb
@@ -87,7 +87,7 @@ module Poms
     Poms::Api::JsonClient.get(
       Poms::Api::Uris::Schedule.now(config.base_uri, channel),
       config.credentials
-    )
+    )['items'].first
   end
 
   # Fetches the event for the next broadcast on a given channel
@@ -97,7 +97,7 @@ module Poms
     Poms::Api::JsonClient.get(
       Poms::Api::Uris::Schedule.next(config.base_uri, channel),
       config.credentials
-    )
+    )['items'].first
   end
 
   def reset_config

--- a/lib/poms.rb
+++ b/lib/poms.rb
@@ -87,7 +87,7 @@ module Poms
     Poms::Api::JsonClient.get(
       Poms::Api::Uris::Schedule.now(config.base_uri, channel),
       config.credentials
-    )['items'].first
+    ).fetch('items').first
   end
 
   # Fetches the event for the next broadcast on a given channel
@@ -97,7 +97,7 @@ module Poms
     Poms::Api::JsonClient.get(
       Poms::Api::Uris::Schedule.next(config.base_uri, channel),
       config.credentials
-    )['items'].first
+    ).fetch('items').first
   end
 
   def reset_config

--- a/lib/poms/api/uris/schedule.rb
+++ b/lib/poms/api/uris/schedule.rb
@@ -10,15 +10,17 @@ module Poms
         module_function
 
         def now(base_uri, channel)
-          uri_for_path(base_uri, "/channel/#{channel}/now")
+          uri_for_path(base_uri, "/channel/#{channel}", {stop: Time.now.iso8601, sort: 'desc', max: 1})
         end
 
         def next(base_uri, channel)
-          uri_for_path(base_uri, "/channel/#{channel}/next")
+          uri_for_path(base_uri, "/channel/#{channel}", {start: Time.now.iso8601, sort: 'asc', max: 1})
         end
 
-        def uri_for_path(base_uri, path = nil)
-          base_uri.merge(path: "#{API_PATH}#{path}")
+        def uri_for_path(base_uri, path = nil, query = {})
+          uri = base_uri.merge(path: "#{API_PATH}#{path}")
+          uri.query_values = query
+          uri
         end
 
         private_class_method :uri_for_path

--- a/lib/poms/api/uris/schedule.rb
+++ b/lib/poms/api/uris/schedule.rb
@@ -10,11 +10,23 @@ module Poms
         module_function
 
         def now(base_uri, channel)
-          uri_for_path(base_uri, "/channel/#{channel}", {stop: Time.now.iso8601, sort: 'desc', max: 1})
+          uri_for_path(
+            base_uri,
+            "/channel/#{channel}",
+            stop: Time.now.iso8601,
+            sort: 'desc',
+            max: 1
+          )
         end
 
         def next(base_uri, channel)
-          uri_for_path(base_uri, "/channel/#{channel}", {start: Time.now.iso8601, sort: 'asc', max: 1})
+          uri_for_path(
+            base_uri,
+            "/channel/#{channel}",
+            start: Time.now.iso8601,
+            sort: 'asc',
+            max: 1
+          )
         end
 
         def uri_for_path(base_uri, path = nil, query = {})

--- a/poms.gemspec
+++ b/poms.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
 end

--- a/spec/fixtures/vcr_cassettes/poms_scheduled_next/has_a_mid.yml
+++ b/spec/fixtures/vcr_cassettes/poms_scheduled_next/has_a_mid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO/next
+    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO?max=1&sort=asc&start=2016-01-01T12:00:00%2B01:00
     body:
       encoding: US-ASCII
       string: ''
@@ -18,16 +18,16 @@ http_interactions:
       Origin:
       - "<POMS_ORIGIN>"
       X-Npo-Date:
-      - Wed, 11 May 2016 10:59:28 +0200
+      - Fri, 01 Jan 2016 12:00:00 +0100
       Authorization:
-      - NPO <POMS_KEY>:lFrmAf28OYVUrRugU+WQ2ysoQR8pD1c9V6pTGNJxlvs=
+      - NPO <POMS_KEY>:zg6Ooxcpe/4Ov+2/96L6Fx9StqLzHYpzdMuU1xsEqkw=
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 11 May 2016 08:59:29 GMT
+      - Fri, 03 Jun 2016 15:43:30 GMT
       Server:
       - Apache/2.4.20 (Unix) OpenSSL/1.0.2g
       Cache-Control:
@@ -54,14 +54,15 @@ http_interactions:
       Content-Type:
       - application/json
       X-Proxyinstancename:
-      - poms1b
+      - poms1a
       Set-Cookie:
-      - balancer://poms8cluster=balancer.poms8bas; path=/;
+      - balancer://poms8cluster=balancer.poms8aas; path=/;
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"textSubtitles":"Teletekst ondertitels","guideDay":1462917600000,"start":1462957800000,"duration":960000,"channel":"OPVO","urnRef":"urn:vpro:media:program:73684990","midRef":"T_POW_03080274","media":{"objectType":"program","mid":"T_POW_03080274","type":"BROADCAST","avType":"VIDEO","sortDate":1462945500000,"urn":"urn:vpro:media:program:73684990","embeddable":true,"broadcasters":[{"id":"AVTR","value":"AVROTROS"}],"titles":[{"value":"Zappsport","owner":"MIS","type":"MAIN"}],"genres":[],"countries":[],"languages":[]}}'
+      string: '{"total":7451,"offset":0,"max":1,"items":[{"guideDay":1451602800000,"start":1451651100000,"duration":663000,"channel":"OPVO","urnRef":"urn:vpro:media:program:67285612","midRef":"T_POW_00655909","media":{"objectType":"program","mid":"T_POW_00655909","type":"BROADCAST","avType":"VIDEO","sortDate":1451627400000,"urn":"urn:vpro:media:program:67285612","embeddable":true,"broadcasters":[{"id":"AVRO","value":"AVRO"}],"titles":[{"value":"Twisted
+        Whiskers","owner":"MIS","type":"MAIN"},{"value":"Oost west-thuis best","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}]}'
     http_version: 
-  recorded_at: Wed, 11 May 2016 08:59:29 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Fri, 01 Jan 2016 11:00:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/poms_scheduled_next/only_returns_broadcasts.yml
+++ b/spec/fixtures/vcr_cassettes/poms_scheduled_next/only_returns_broadcasts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO/next
+    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO?max=1&sort=asc&start=2016-01-01T12:00:00%2B01:00
     body:
       encoding: US-ASCII
       string: ''
@@ -18,16 +18,16 @@ http_interactions:
       Origin:
       - "<POMS_ORIGIN>"
       X-Npo-Date:
-      - Wed, 11 May 2016 10:59:28 +0200
+      - Fri, 01 Jan 2016 12:00:00 +0100
       Authorization:
-      - NPO <POMS_KEY>:lFrmAf28OYVUrRugU+WQ2ysoQR8pD1c9V6pTGNJxlvs=
+      - NPO <POMS_KEY>:zg6Ooxcpe/4Ov+2/96L6Fx9StqLzHYpzdMuU1xsEqkw=
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 11 May 2016 08:59:28 GMT
+      - Fri, 03 Jun 2016 15:43:30 GMT
       Server:
       - Apache/2.4.20 (Unix) OpenSSL/1.0.2g
       Cache-Control:
@@ -54,14 +54,15 @@ http_interactions:
       Content-Type:
       - application/json
       X-Proxyinstancename:
-      - poms1b
+      - poms1a
       Set-Cookie:
-      - balancer://poms8cluster=balancer.poms8bas; path=/;
+      - balancer://poms8cluster=balancer.poms8aas; path=/;
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"textSubtitles":"Teletekst ondertitels","guideDay":1462917600000,"start":1462957800000,"duration":960000,"channel":"OPVO","urnRef":"urn:vpro:media:program:73684990","midRef":"T_POW_03080274","media":{"objectType":"program","mid":"T_POW_03080274","type":"BROADCAST","avType":"VIDEO","sortDate":1462945500000,"urn":"urn:vpro:media:program:73684990","embeddable":true,"broadcasters":[{"id":"AVTR","value":"AVROTROS"}],"titles":[{"value":"Zappsport","owner":"MIS","type":"MAIN"}],"genres":[],"countries":[],"languages":[]}}'
+      string: '{"total":7451,"offset":0,"max":1,"items":[{"guideDay":1451602800000,"start":1451651100000,"duration":663000,"channel":"OPVO","urnRef":"urn:vpro:media:program:67285612","midRef":"T_POW_00655909","media":{"objectType":"program","mid":"T_POW_00655909","type":"BROADCAST","avType":"VIDEO","sortDate":1451627400000,"urn":"urn:vpro:media:program:67285612","embeddable":true,"broadcasters":[{"id":"AVRO","value":"AVRO"}],"titles":[{"value":"Twisted
+        Whiskers","owner":"MIS","type":"MAIN"},{"value":"Oost west-thuis best","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}]}'
     http_version: 
-  recorded_at: Wed, 11 May 2016 08:59:28 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Fri, 01 Jan 2016 11:00:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/poms_scheduled_next/returns_the_current_event.yml
+++ b/spec/fixtures/vcr_cassettes/poms_scheduled_next/returns_the_current_event.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO/next
+    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO?max=1&sort=asc&start=2016-01-01T12:00:00%2B01:00
     body:
       encoding: US-ASCII
       string: ''
@@ -18,16 +18,16 @@ http_interactions:
       Origin:
       - "<POMS_ORIGIN>"
       X-Npo-Date:
-      - Wed, 11 May 2016 10:59:27 +0200
+      - Fri, 01 Jan 2016 12:00:00 +0100
       Authorization:
-      - NPO <POMS_KEY>:5QqooaAx720peO5hFDeH0MvH54tXQ8gdjLEzwa26pI4=
+      - NPO <POMS_KEY>:zg6Ooxcpe/4Ov+2/96L6Fx9StqLzHYpzdMuU1xsEqkw=
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 11 May 2016 08:59:28 GMT
+      - Fri, 03 Jun 2016 15:43:29 GMT
       Server:
       - Apache/2.4.20 (Unix) OpenSSL/1.0.2g
       Cache-Control:
@@ -56,12 +56,13 @@ http_interactions:
       X-Proxyinstancename:
       - poms1a
       Set-Cookie:
-      - balancer://poms8cluster=balancer.poms8bas; path=/;
+      - balancer://poms8cluster=balancer.poms8aas; path=/;
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"textSubtitles":"Teletekst ondertitels","guideDay":1462917600000,"start":1462957800000,"duration":960000,"channel":"OPVO","urnRef":"urn:vpro:media:program:73684990","midRef":"T_POW_03080274","media":{"objectType":"program","mid":"T_POW_03080274","type":"BROADCAST","avType":"VIDEO","sortDate":1462945500000,"urn":"urn:vpro:media:program:73684990","embeddable":true,"broadcasters":[{"id":"AVTR","value":"AVROTROS"}],"titles":[{"value":"Zappsport","owner":"MIS","type":"MAIN"}],"genres":[],"countries":[],"languages":[]}}'
+      string: '{"total":7451,"offset":0,"max":1,"items":[{"guideDay":1451602800000,"start":1451651100000,"duration":663000,"channel":"OPVO","urnRef":"urn:vpro:media:program:67285612","midRef":"T_POW_00655909","media":{"objectType":"program","mid":"T_POW_00655909","type":"BROADCAST","avType":"VIDEO","sortDate":1451627400000,"urn":"urn:vpro:media:program:67285612","embeddable":true,"broadcasters":[{"id":"AVRO","value":"AVRO"}],"titles":[{"value":"Twisted
+        Whiskers","owner":"MIS","type":"MAIN"},{"value":"Oost west-thuis best","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}]}'
     http_version: 
-  recorded_at: Wed, 11 May 2016 08:59:28 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Fri, 01 Jan 2016 11:00:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/poms_scheduled_now/has_a_mid.yml
+++ b/spec/fixtures/vcr_cassettes/poms_scheduled_now/has_a_mid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO/now
+    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO?max=1&sort=desc&stop=2016-01-01T12:00:00%2B01:00
     body:
       encoding: US-ASCII
       string: ''
@@ -18,16 +18,16 @@ http_interactions:
       Origin:
       - "<POMS_ORIGIN>"
       X-Npo-Date:
-      - Fri, 06 May 2016 15:20:57 +0200
+      - Fri, 01 Jan 2016 12:00:00 +0100
       Authorization:
-      - NPO <POMS_KEY>:X2dGRXB0W/9B+nG+GK7OeujbFQlQIj9NvbfBkh7OL2s=
+      - NPO <POMS_KEY>:SrS7KcCnKPjpYjCia+nxiMH1q3kQ0DcfKrRLdvYVXeg=
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 06 May 2016 13:20:57 GMT
+      - Fri, 03 Jun 2016 15:43:29 GMT
       Server:
       - Apache/2.4.20 (Unix) OpenSSL/1.0.2g
       Cache-Control:
@@ -61,8 +61,8 @@ http_interactions:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"guideDay":1462485600000,"start":1462540500000,"duration":870000,"channel":"OPVO","urnRef":"urn:vpro:media:program:71174223","midRef":"T_POW_00468217","media":{"objectType":"program","mid":"T_POW_00468217","type":"BROADCAST","avType":"VIDEO","sortDate":1457531100000,"urn":"urn:vpro:media:program:71174223","embeddable":true,"broadcasters":[{"id":"TROS","value":"TROS"}],"titles":[{"value":"De
-        Wereld van K3","owner":"MIS","type":"MAIN"},{"value":"Memobord","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}'
+      string: '{"total":6144,"offset":0,"max":1,"items":[{"guideDay":1451602800000,"start":1451640300000,"duration":1380000,"channel":"OPVO","urnRef":"urn:vpro:media:program:34611931","midRef":"T_POW_00753962","media":{"objectType":"program","mid":"T_POW_00753962","type":"BROADCAST","avType":"VIDEO","sortDate":1388809260000,"urn":"urn:vpro:media:program:34611931","embeddable":true,"broadcasters":[{"id":"TROS","value":"TROS"}],"titles":[{"value":"Mickey
+        Mouse clubhuis","owner":"MIS","type":"MAIN"},{"value":"De doorzetters","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}]}'
     http_version: 
-  recorded_at: Fri, 06 May 2016 13:20:57 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Fri, 01 Jan 2016 11:00:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/poms_scheduled_now/only_returns_broadcasts.yml
+++ b/spec/fixtures/vcr_cassettes/poms_scheduled_now/only_returns_broadcasts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO/now
+    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO?max=1&sort=desc&stop=2016-01-01T12:00:00%2B01:00
     body:
       encoding: US-ASCII
       string: ''
@@ -18,16 +18,16 @@ http_interactions:
       Origin:
       - "<POMS_ORIGIN>"
       X-Npo-Date:
-      - Fri, 06 May 2016 15:20:57 +0200
+      - Fri, 01 Jan 2016 12:00:00 +0100
       Authorization:
-      - NPO <POMS_KEY>:X2dGRXB0W/9B+nG+GK7OeujbFQlQIj9NvbfBkh7OL2s=
+      - NPO <POMS_KEY>:SrS7KcCnKPjpYjCia+nxiMH1q3kQ0DcfKrRLdvYVXeg=
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 06 May 2016 13:20:57 GMT
+      - Fri, 03 Jun 2016 15:43:29 GMT
       Server:
       - Apache/2.4.20 (Unix) OpenSSL/1.0.2g
       Cache-Control:
@@ -61,8 +61,8 @@ http_interactions:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"guideDay":1462485600000,"start":1462540500000,"duration":870000,"channel":"OPVO","urnRef":"urn:vpro:media:program:71174223","midRef":"T_POW_00468217","media":{"objectType":"program","mid":"T_POW_00468217","type":"BROADCAST","avType":"VIDEO","sortDate":1457531100000,"urn":"urn:vpro:media:program:71174223","embeddable":true,"broadcasters":[{"id":"TROS","value":"TROS"}],"titles":[{"value":"De
-        Wereld van K3","owner":"MIS","type":"MAIN"},{"value":"Memobord","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}'
+      string: '{"total":6144,"offset":0,"max":1,"items":[{"guideDay":1451602800000,"start":1451640300000,"duration":1380000,"channel":"OPVO","urnRef":"urn:vpro:media:program:34611931","midRef":"T_POW_00753962","media":{"objectType":"program","mid":"T_POW_00753962","type":"BROADCAST","avType":"VIDEO","sortDate":1388809260000,"urn":"urn:vpro:media:program:34611931","embeddable":true,"broadcasters":[{"id":"TROS","value":"TROS"}],"titles":[{"value":"Mickey
+        Mouse clubhuis","owner":"MIS","type":"MAIN"},{"value":"De doorzetters","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}]}'
     http_version: 
-  recorded_at: Fri, 06 May 2016 13:20:57 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Fri, 01 Jan 2016 11:00:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/poms_scheduled_now/returns_the_current_event.yml
+++ b/spec/fixtures/vcr_cassettes/poms_scheduled_now/returns_the_current_event.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO/now
+    uri: https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO?max=1&sort=desc&stop=2016-01-01T12:00:00%2B01:00
     body:
       encoding: US-ASCII
       string: ''
@@ -18,16 +18,16 @@ http_interactions:
       Origin:
       - "<POMS_ORIGIN>"
       X-Npo-Date:
-      - Fri, 06 May 2016 15:20:57 +0200
+      - Fri, 01 Jan 2016 12:00:00 +0100
       Authorization:
-      - NPO <POMS_KEY>:X2dGRXB0W/9B+nG+GK7OeujbFQlQIj9NvbfBkh7OL2s=
+      - NPO <POMS_KEY>:SrS7KcCnKPjpYjCia+nxiMH1q3kQ0DcfKrRLdvYVXeg=
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 06 May 2016 13:20:57 GMT
+      - Fri, 03 Jun 2016 15:43:29 GMT
       Server:
       - Apache/2.4.20 (Unix) OpenSSL/1.0.2g
       Cache-Control:
@@ -54,15 +54,15 @@ http_interactions:
       Content-Type:
       - application/json
       X-Proxyinstancename:
-      - poms1b
+      - poms1a
       Set-Cookie:
       - balancer://poms8cluster=balancer.poms8aas; path=/;
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"guideDay":1462485600000,"start":1462540500000,"duration":870000,"channel":"OPVO","urnRef":"urn:vpro:media:program:71174223","midRef":"T_POW_00468217","media":{"objectType":"program","mid":"T_POW_00468217","type":"BROADCAST","avType":"VIDEO","sortDate":1457531100000,"urn":"urn:vpro:media:program:71174223","embeddable":true,"broadcasters":[{"id":"TROS","value":"TROS"}],"titles":[{"value":"De
-        Wereld van K3","owner":"MIS","type":"MAIN"},{"value":"Memobord","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}'
+      string: '{"total":6144,"offset":0,"max":1,"items":[{"guideDay":1451602800000,"start":1451640300000,"duration":1380000,"channel":"OPVO","urnRef":"urn:vpro:media:program:34611931","midRef":"T_POW_00753962","media":{"objectType":"program","mid":"T_POW_00753962","type":"BROADCAST","avType":"VIDEO","sortDate":1388809260000,"urn":"urn:vpro:media:program:34611931","embeddable":true,"broadcasters":[{"id":"TROS","value":"TROS"}],"titles":[{"value":"Mickey
+        Mouse clubhuis","owner":"MIS","type":"MAIN"},{"value":"De doorzetters","owner":"MIS","type":"SUB"}],"genres":[],"countries":[],"languages":[]}}]}'
     http_version: 
-  recorded_at: Fri, 06 May 2016 13:20:57 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Fri, 01 Jan 2016 11:00:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/integration/poms_spec.rb
+++ b/spec/integration/poms_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe Poms do
   end
 
   describe '.scheduled_now' do
+    before do
+      Timecop.freeze(Time.local(2016, 1, 1, 12, 0, 0))
+    end
+
+    after do
+      Timecop.return
+    end
+
     subject { described_class.scheduled_now('OPVO') }
 
     it 'returns the current event' do
@@ -126,6 +134,14 @@ RSpec.describe Poms do
   end
 
   describe '.scheduled_next' do
+    before do
+      Timecop.freeze(Time.local(2016, 1, 1, 12, 0, 0))
+    end
+
+    after do
+      Timecop.return
+    end
+
     subject { described_class.scheduled_next('OPVO') }
 
     it 'returns the current event' do

--- a/spec/lib/poms/api/uris/schedule_spec.rb
+++ b/spec/lib/poms/api/uris/schedule_spec.rb
@@ -8,19 +8,37 @@ module Poms
         let(:base_uri) { Addressable::URI.parse('https://rs.poms.omroep.nl') }
 
         describe '.now' do
-          it 'returns the correct uri for channel' do
-            uri = described_class.now(base_uri, 'OPVO')
-            expect(uri.to_s).to eql(
-              'https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO/now'
+          subject { described_class.now(base_uri, 'OPVO') }
+
+          it 'returns the correct uri path for channel' do
+            expect(subject.path).to eql(
+              '/v1/api/schedule/channel/OPVO'
+            )
+          end
+
+          it 'returns the correct query' do
+            expect(subject.query_values).to include("stop")
+            expect(subject.query_values).to include(
+              "max" => "1",
+              "sort" => "desc"
             )
           end
         end
 
         describe '.next' do
+          subject { described_class.next(base_uri, 'OPVO') }
+
           it 'returns the correct uri for channel' do
-            uri = described_class.next(base_uri, 'OPVO')
-            expect(uri.to_s).to eql(
-              'https://rs.poms.omroep.nl/v1/api/schedule/channel/OPVO/next'
+            expect(subject.path).to eql(
+              '/v1/api/schedule/channel/OPVO'
+            )
+          end
+
+          it 'returns the correct query' do
+            expect(subject.query_values).to include("start")
+            expect(subject.query_values).to include(
+              "max" => "1",
+              "sort" => "asc"
             )
           end
         end

--- a/spec/lib/poms/api/uris/schedule_spec.rb
+++ b/spec/lib/poms/api/uris/schedule_spec.rb
@@ -17,10 +17,10 @@ module Poms
           end
 
           it 'returns the correct query' do
-            expect(subject.query_values).to include("stop")
+            expect(subject.query_values).to include('stop')
             expect(subject.query_values).to include(
-              "max" => "1",
-              "sort" => "desc"
+              'max' => '1',
+              'sort' => 'desc'
             )
           end
         end
@@ -35,10 +35,10 @@ module Poms
           end
 
           it 'returns the correct query' do
-            expect(subject.query_values).to include("start")
+            expect(subject.query_values).to include('start')
             expect(subject.query_values).to include(
-              "max" => "1",
-              "sort" => "asc"
+              'max' => '1',
+              'sort' => 'asc'
             )
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ SimpleCov.start
 require 'rubygems'
 require 'bundler/setup'
 require 'webmock/rspec'
+require 'timecop'
 require 'vcr'
 require 'active_support/all'
 


### PR DESCRIPTION
Poms returns a 404 when there is nothing currently on tv for the /now and /next channel endpoints. This caused problems in out apps, so we now use the schedule endpoint to either return the most recent thing on tv or the next thing on. This should prevent the endpoint from returning nothing (or a 404).