### PR TITLE
Schedule events filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.0
 
+* Allow `schedule_events` to accept a block which allows you to filter the events.
 * The `scheduled_now` and `scheduled_next` functions always return the most recent and upcoming shows. They shouldn't return nil anymore, even if something is not live at the moment (during a commercial break for instance).
 
 ## 2.0.1

--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -71,15 +71,27 @@ module Poms
       parent.first['index'] if parent.present?
     end
 
+    # Returns an array of start and end times for the  scheduled events for
+    # this item. It returns an empty array if no events are found. You can pass
+    # in a block to filter the events on data that is not returned, like
+    # channel.
+    #
+    # @param item The Poms hash
     def schedule_events(item)
       events = item.fetch('scheduleEvents', [])
-      events.map do |event|
-        {
-          'starts_at' => Timestamp.to_datetime(event['start']),
-          'ends_at' => Timestamp.to_datetime(event['start'] + event['duration'])
-        }
-      end
+      events = yield(events) if block_given?
+      events.map { |event| hash_event(event) }
     end
+
+    # Turns the event into a hash.
+    def hash_event(event)
+      {
+        'starts_at' => Timestamp.to_datetime(event.fetch('start')),
+        'ends_at' => Timestamp.to_datetime(event.fetch('start') +
+          event.fetch('duration'))
+      }
+    end
+    private_class_method :hash_event
 
     # Poms has arrays of hashes for some types that have a value and type. This
     # is a way to access those simply.
@@ -98,7 +110,6 @@ module Poms
       return unless res
       res['value']
     end
-
     private_class_method :value_of_type
   end
 end

--- a/spec/fixtures/poms_broadcast.json
+++ b/spec/fixtures/poms_broadcast.json
@@ -271,6 +271,19 @@
             "poSeriesID": "KRO_1521173",
             "start": 1369757335000,
             "urnRef": "urn:vpro:media:program:25215266"
+        },
+        {
+            "repeat": {
+                "isRerun": true
+            },
+            "textSubtitles": "Teletekst ondertitels",
+            "guideDay": 1464732000000,
+            "start": 1464792900000,
+            "duration": 1269000,
+            "poProgID": "KRO_1614405",
+            "channel": "BVNT",
+            "urnRef": "urn:vpro:media:program:47289723",
+            "midRef": "KRO_1614405"
         }
     ],
     "segments": [],

--- a/spec/lib/poms/fields_spec.rb
+++ b/spec/lib/poms/fields_spec.rb
@@ -121,12 +121,40 @@ naar hun loods, maar is dat wel een goed idee?")
     end
 
     describe '.schedule_events' do
+      it 'returns an empty array if there are no scheduled events' do
+        expect(described_class.schedule_events({})).to eq([])
+      end
+
+      it 'raises keyerror when the events do not have the right keys' do
+        expect {
+          described_class.schedule_events(
+            'scheduleEvents' => [{ 'start' => 10 }]
+          )
+        }.to raise_error(KeyError)
+      end
+
       it 'returns a collection of objects with a start and end time' do
-        expect(described_class.schedule_events(poms_data)).to include(
-          {
-            'starts_at' => Timestamp.to_datetime(1_369_757_335_000),
-            'ends_at' => Timestamp.to_datetime(1_369_758_384_000)
-          }
+        expect(described_class.schedule_events(poms_data)).to match_array(
+          [
+            {
+              'starts_at' => Timestamp.to_datetime(1_369_757_335_000),
+              'ends_at' => Timestamp.to_datetime(1_369_758_384_000)
+            },
+            {
+              'starts_at' => Timestamp.to_datetime(1_464_792_900_000),
+              'ends_at' => Timestamp.to_datetime(1_464_794_169_000)
+            }
+          ]
+        )
+      end
+
+      it 'accepts a block with events' do
+        result = described_class.schedule_events(poms_data) do |events|
+          events.reject { |e| e['channel'] == 'BVNT' }
+        end
+        expect(result).not_to include(
+          'starts_at' => Timestamp.to_datetime(1_464_792_900_000),
+          'ends_at' => Timestamp.to_datetime(1_464_794_169_000)
         )
       end
     end

--- a/spec/lib/poms/fields_spec.rb
+++ b/spec/lib/poms/fields_spec.rb
@@ -122,14 +122,11 @@ naar hun loods, maar is dat wel een goed idee?")
 
     describe '.schedule_events' do
       it 'returns a collection of objects with a start and end time' do
-        expect(described_class.schedule_events(poms_data)).to eq(
-          [
-            {
-              'starts_at' => Timestamp.to_datetime(1_369_757_335_000),
-              'ends_at' => Timestamp.to_datetime(1_369_758_384_000)
-
-            }
-          ]
+        expect(described_class.schedule_events(poms_data)).to include(
+          {
+            'starts_at' => Timestamp.to_datetime(1_369_757_335_000),
+            'ends_at' => Timestamp.to_datetime(1_369_758_384_000)
+          }
         )
       end
     end


### PR DESCRIPTION
This PR allows you to pass a block to `schedule_events` which allows you to filter the events that are returned.