### PR TITLE
Extend Poms::Fields.position to take in optional :member_of

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Style/AndOr:
     - 'lib/poms.rb' # here we do rely on how `or` has lower precedence than `||`
     - 'lib/poms/configuration.rb' # here we do rely on how `or` has lower precedence than `||`
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 ModuleLength:
   Exclude:
     - spec/**/*_spec.rb # specs are only in module for easier access to functions

--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -73,10 +73,21 @@ module Poms
     # @param optional :member_of The midref of parent for which we
     # seek the index
     def position(item, member_of: nil)
+      parent(item, midref: member_of).try(:[], 'index')
+    end
+
+    # Finds a parent the data is "member of". If :midref is given, it
+    # will look for the parent that matches that mid and return nil if
+    # not found. Without the :midref it will return the first parent
+    # @param item The Poms Hash
+    # @param optional midref The midref of parent we seek.
+    def parent(item, midref: nil)
       parents = Array(item['memberOf'])
-      return if parents.empty?
-      return parents.first['index'] if member_of.blank?
-      Hash(parents.find { |parent| parent['midRef'] == member_of })['index']
+      if midref
+        parents.find { |parent| parent['midRef'] == midref }
+      else
+        parents.first
+      end
     end
 
     # Returns an array of start and end times for the  scheduled events for

--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -65,10 +65,17 @@ module Poms
       Timestamp.to_datetime(internetvod['publishStop'])
     end
 
-    # Returns the position in the parent context if it is present.
-    def position(item)
-      parent = item['memberOf']
-      parent.first['index'] if parent.present?
+    # Returns the index at which it is in the parent. When no
+    # :member_of keyword is given, it will return the first found
+    # index. Else, when a parent is found with matching member_of
+    # midref, it returns that index. Else returns nil.
+    # @param item The Poms Hash
+    # @param optional :member_of The midref of parent for which we seek the index
+    def position(item, member_of: nil)
+      parents = Array(item['memberOf'])
+      return if parents.empty?
+      return parents.first['index'] if member_of.blank?
+      Hash(parents.find { |parent| parent['midRef'] == member_of })['index']
     end
 
     # Returns an array of start and end times for the  scheduled events for

--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -78,16 +78,21 @@ module Poms
 
     # Finds a parent the data is "member of". If :midref is given, it
     # will look for the parent that matches that mid and return nil if
-    # not found. Without the :midref it will return the first parent
+    # not found. Without the :midref it will return the first parent.
     # @param item The Poms Hash
     # @param optional midref The midref of parent we seek.
     def parent(item, midref: nil)
-      parents = Array(item['memberOf'])
       if midref
-        parents.find { |parent| parent['midRef'] == midref }
+        parents(item).find { |parent| parent['midRef'] == midref }
       else
-        parents.first
+        parents(item).first
       end
+    end
+
+    # Returns the parents that the element is member of. Will always
+    # return an array.
+    def parents(item)
+      Array(item['memberOf'])
     end
 
     # Returns an array of start and end times for the  scheduled events for

--- a/lib/poms/fields.rb
+++ b/lib/poms/fields.rb
@@ -70,7 +70,8 @@ module Poms
     # index. Else, when a parent is found with matching member_of
     # midref, it returns that index. Else returns nil.
     # @param item The Poms Hash
-    # @param optional :member_of The midref of parent for which we seek the index
+    # @param optional :member_of The midref of parent for which we
+    # seek the index
     def position(item, member_of: nil)
       parents = Array(item['memberOf'])
       return if parents.empty?

--- a/spec/fixtures/poms_clip.json
+++ b/spec/fixtures/poms_clip.json
@@ -58,12 +58,19 @@
   ],
   "memberOf": [
     {
-      "midRef": "POMS_S_NPO_818759",
-      "urnRef": "urn:vpro:media:group:53045541",
+      "midRef": "POMS_S_ZAPP_4101943",
+      "urnRef": "urn:vpro:media:group:77721008",
+      "type": "SERIES",
+      "index": 31,
+      "highlighted": false,
+      "added": 1467374331588},
+    {
+      "midRef": "POMS_S_ZAPP_4110813",
+      "urnRef": "urn:vpro:media:group:77777901",
       "type": "PLAYLIST",
       "index": 1,
       "highlighted": false,
-      "added": 1427284134408
+      "added": 1467374346116
     }
   ],
   "locations": [

--- a/spec/lib/poms/fields_spec.rb
+++ b/spec/lib/poms/fields_spec.rb
@@ -110,13 +110,30 @@ naar hun loods, maar is dat wel een goed idee?")
     end
 
     describe '.position' do
-      it 'returns the position' do
-        clip = JSON.parse File.read('spec/fixtures/poms_clip.json')
-        expect(described_class.position(clip)).to eq(1)
+      let(:clip) { JSON.parse(File.read('spec/fixtures/poms_clip.json')) }
+
+      context 'with no extra arguments' do
+        it "returns the clip's index for his first parent" do
+          expect(described_class.position(clip)).to eq(31)
+        end
       end
 
-      it 'returns nil if it not a member of anything' do
-        expect(described_class.position(poms_data)).to be_nil
+      context 'with no parents' do
+        it 'returns nil' do
+          expect(described_class.position('memberOf' => [])).to be_nil
+          expect(described_class.position({})).to be_nil
+        end
+      end
+
+      context 'When given an ancestor midRef' do
+        it "returns the clip's index in that parent" do
+          pos = described_class.position(clip, member_of: 'POMS_S_ZAPP_4110813')
+          expect(pos).to eql(1)
+        end
+
+        it 'returns nil if no matching parent found' do
+          expect(described_class.position(clip, member_of: 'nobody')).to be_nil
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,8 +25,8 @@ RSpec.configure do |config|
       VCR.turned_off(&example)
     else
       name = example.metadata[:full_description]
-             .split(/\s+/, 2).join('/')
-             .underscore.gsub(%r{[^\w\/]+}, '_')
+                    .split(/\s+/, 2).join('/')
+                    .underscore.gsub(%r{[^\w\/]+}, '_')
       VCR.use_cassette(name, options, &example)
     end
   end


### PR DESCRIPTION
``` json
  "memberOf": [
    {
      "midRef": "POMS_S_ZAPP_4101943",
      "urnRef": "urn:vpro:media:group:77721008",
      "type": "SERIES",
      "index": 31,
      "highlighted": false,
      "added": 1467374331588},
    {
      "midRef": "POMS_S_ZAPP_4110813",
      "urnRef": "urn:vpro:media:group:77777901",
      "type": "PLAYLIST",
      "index": 1,
      "highlighted": false,
      "added": 1467374346116
    }
  ]
```

Before `Poms::Fields.position` would only grab the first member's index. We need a way to fetch the index for the matching member, eg by querying on a certain parent `midRef`.