### PR TITLE
Require Poms::Fields in the main interface

### DIFF
--- a/lib/poms.rb
+++ b/lib/poms.rb
@@ -6,6 +6,7 @@ require 'poms/api/request'
 require 'poms/errors'
 require 'poms/api/search'
 require 'poms/configuration'
+require 'poms/fields'
 require 'json'
 
 # Main interface for the POMS gem


### PR DESCRIPTION
Poms::Fields isn't loaded by default if you use this gem. This leads to problems where Poms::Fields cannot be accessed when you don't explicitly require it in the app using the Poms Gem.

By requiring it in the main interface file, we ensure it is loaded whenever you use the Poms Gem.